### PR TITLE
Update for address and typo...

### DIFF
--- a/.default.env
+++ b/.default.env
@@ -15,7 +15,7 @@ API_KEY=""
 # ============================================================================
 
 # Ethereum Contract addresses
-OPR_DIST_CONTRACT_ADDR=0x1234567890123456789012345678901234567890
+OPR_DIST_CONTRACT_ADDR=0x102809fe582ecaa527bb316dcc4e99fc35fbabb9
 SUPERNODE_ACC_ADDR=0x2a906f92b0378bb19a3619e2751b1e0b8cab6b29
 
 # Bond amount for newly created minipools in wei (10^-18)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ When a shell script is run from an SSH session, as soon as the pipe is broken an
     `kill %<job_number>`
 
 5. If you want the job to continue running even after you log out, you can `disown` it after starting it:  
-    `disown -h %1  # Replace 1 with the job number if different`
+    `disown %1  # Replace 1 with the job number if different`
 
 6. Since disowned jobs become regular processes, you can list them using `ps`:  
     `ps aux | grep minilaunch.sh`


### PR DESCRIPTION
Contract address was just a placeholder and typo in the README for `disown`